### PR TITLE
Windows 2019 reboot loop workaround

### DIFF
--- a/update/windows-update.ps1
+++ b/update/windows-update.ps1
@@ -177,10 +177,8 @@ for ($i = 0; $i -lt $searchResult.Updates.Count; ++$i) {
 
     $update.AcceptEula() | Out-Null
 
-    if (!$update.IsDownloaded) {
-        $updatesToDownloadSize += $update.MaxDownloadSize
-        $updatesToDownload.Add($update) | Out-Null
-    }
+    $updatesToDownloadSize += $update.MaxDownloadSize
+    $updatesToDownload.Add($update) | Out-Null
 
     $updatesToInstall.Add($update) | Out-Null
     if ($updatesToInstall.Count -ge $UpdateLimit) {


### PR DESCRIPTION
A quick and dirty workaround for the current windows server 2019 boot loop issue. It is not pretty, but working.

Fixes #30 
Fixes #23 