### PR TITLE
Windows 7 target support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/update/*.ps1 -text

--- a/update/elevated-template.ps1
+++ b/update/elevated-template.ps1
@@ -64,6 +64,19 @@ while ((!($t.state -eq 4)) -and ($sec -lt $timeout)) {
     Start-Sleep -Seconds 1
     $sec++
 }
+# Windows PowerShell 2 on Windows 7 does not have Get-CimInstance.
+# PowerShell 6 does not have Get-WmiObject.
+if (!(Get-Command Get-CimInstance -ErrorAction:SilentlyContinue)) {
+    function Get-CimInstance {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory = $True, Position = 0)]
+            [string]
+            $ClassName
+        )
+        Get-WmiObject -Class $ClassName
+    }
+}
 $reportProgressInterval = New-TimeSpan -Minutes 1
 $startDate = Get-Date
 $line = 0

--- a/update/windows-update.ps1
+++ b/update/windows-update.ps1
@@ -232,6 +232,11 @@ if ($updatesToDownload.Count) {
         if ($downloadResult.ResultCode -eq 2) {
             break
         }
+        if ($downloadResult.ResultCode -eq 3) {
+            Write-Output "Download Windows updates succeeded with errors. Will retry after installing updates."
+            $rebootRequired = $true
+            break
+        }
         $downloadStatus = LookupOperationResultCode($downloadResult.ResultCode) 
         Write-Output "Download Windows updates failed with $downloadStatus. Retrying..."
         Start-Sleep -Seconds 5


### PR DESCRIPTION
- `Get-CimInstance` is not a command in PowerShell 2.0.
- Sometimes when you are years out of date, Windows Update will fail to download certain updates. Maybe these updates are superseded or another update is required before that update can be downloaded. If the script allows installation to continue even when some updates failed to download, and then it reboots and retries the download until everything is installed, this seems to work.