### PR TITLE
Feature/retry on install failure

### DIFF
--- a/update/windows-update.ps1
+++ b/update/windows-update.ps1
@@ -247,8 +247,11 @@ if ($updatesToInstall.Count) {
     Write-Output 'Installing Windows updates...'
     $updateInstaller = $updateSession.CreateUpdateInstaller()
     $updateInstaller.Updates = $updatesToInstall
+
+    $installRebootRequired = $false
     try {
         $installResult = $updateInstaller.Install()
+        $installRebootRequired = $installResult.RebootRequired
     } catch {
         Write-Warning "Windows update installation failed with error:"
         Write-Warning $_.Exception.ToString()
@@ -257,7 +260,7 @@ if ($updatesToInstall.Count) {
         # restart the machine and try again
         $rebootRequired = $true
     }
-    ExitWhenRebootRequired ($installResult.RebootRequired -or $rebootRequired)
+    ExitWhenRebootRequired ($installRebootRequired -or $rebootRequired)
 } else {
     ExitWhenRebootRequired $rebootRequired
     Write-Output 'No Windows updates found'

--- a/update/windows-update.ps1
+++ b/update/windows-update.ps1
@@ -113,7 +113,7 @@ $operationResultCodes = @{
 function LookupOperationResultCode($code) {
     if ($operationResultCodes.ContainsKey($code)) {
         return $operationResultCodes[$code]
-    } 
+    }
     return "Unknown Code $code"
 }
 
@@ -178,9 +178,9 @@ while ($true) {
             break
         }
         $searchStatus = LookupOperationResultCode($searchResult.ResultCode)
-    } catch {        
+    } catch {
         $searchStatus = $_.ToString()
-    }    
+    }
     Write-Output "Search for Windows updates failed with '$searchStatus'. Retrying..."
     Start-Sleep -Seconds 5
 }
@@ -237,7 +237,7 @@ if ($updatesToDownload.Count) {
             $rebootRequired = $true
             break
         }
-        $downloadStatus = LookupOperationResultCode($downloadResult.ResultCode) 
+        $downloadStatus = LookupOperationResultCode($downloadResult.ResultCode)
         Write-Output "Download Windows updates failed with $downloadStatus. Retrying..."
         Start-Sleep -Seconds 5
     }
@@ -247,7 +247,16 @@ if ($updatesToInstall.Count) {
     Write-Output 'Installing Windows updates...'
     $updateInstaller = $updateSession.CreateUpdateInstaller()
     $updateInstaller.Updates = $updatesToInstall
-    $installResult = $updateInstaller.Install()
+    try {
+        $installResult = $updateInstaller.Install()
+    } catch {
+        Write-Warning "Windows update installation failed with error:"
+        Write-Warning $_.Exception.ToString()
+
+        # Windows update install failed for some reason
+        # restart the machine and try again
+        $rebootRequired = $true
+    }
     ExitWhenRebootRequired ($installResult.RebootRequired -or $rebootRequired)
 } else {
     ExitWhenRebootRequired $rebootRequired


### PR DESCRIPTION
In some cases the installation of Windows Updates fails for obscure reasons. Forcing the machine to restart and retry the updates seems to allow the updates to be applied without issues. 

Code changes have been tested in production and do fix the issue. Note that one worry about this code change is that of an infinite loop of restarts if the update keeps failing. Not entirely sure if that is a real issue (i.e. could that occur) and how to determine that is the case and break the loop.

relates to #76